### PR TITLE
Bump Dockerfile Go base image to 1.27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26 AS build
+FROM golang:1.27 AS build
 
 WORKDIR /src
 COPY go.mod go.sum ./


### PR DESCRIPTION
## Summary
The v0.1.8 release docker jobs failed at `go mod download` because the Dockerfile still uses `golang:1.26`, which cannot satisfy the `go 1.27.0` directive added in #25. This bumps the build stage to `golang:1.27`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)